### PR TITLE
Add PCA9685 LED demo

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -15,3 +15,13 @@ framework = arduino
 monitor_speed = 115200
 build_flags = -w
 lib_deps = IBusBM
+build_src_filter = +<src/main.cpp>
+
+[env:ioxesp32ps_pca9685]
+platform = espressif32
+board = ioxesp32ps
+framework = arduino
+monitor_speed = 115200
+build_flags = -w
+lib_deps = adafruit/Adafruit PWM Servo Driver Library
+build_src_filter = +<src/pca9685_led_demo.cpp>

--- a/src/pca9685_led_demo.cpp
+++ b/src/pca9685_led_demo.cpp
@@ -1,0 +1,25 @@
+#include <Arduino.h>
+#include <Wire.h>
+#include <Adafruit_PWMServoDriver.h>
+
+Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver();
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    ;
+  }
+
+  pwm.begin();
+  pwm.setPWMFreq(1000); // Set frequency for LED
+}
+
+void loop() {
+  const uint16_t duty = 2048; // 50% of 4096
+  for (uint8_t ch = 0; ch < 4; ch++) {
+    pwm.setPWM(ch, 0, duty); // Turn channel on at 50%
+    delay(200);
+    pwm.setPWM(ch, 0, 0);    // Turn channel off
+  }
+}
+


### PR DESCRIPTION
## Summary
- provide a simple PCA9685 LED running light example
- allow choosing the example via a new PlatformIO environment

## Testing
- `pio run -e ioxesp32ps_pca9685` *(fails: `pio` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684658ecef6883319feb874b0ed7542c